### PR TITLE
Add secret parameter

### DIFF
--- a/fluent-plugin-azurestorage.gemspec
+++ b/fluent-plugin-azurestorage.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
 
   spec.add_runtime_dependency "fluentd"
+  spec.add_runtime_dependency "fluent-mixin-config-placeholders"
   spec.add_runtime_dependency "azure"
 end

--- a/lib/fluent/plugin/out_azurestorage.rb
+++ b/lib/fluent/plugin/out_azurestorage.rb
@@ -15,7 +15,7 @@ module Fluent
 
     config_param :path, :string, :default => ''
     config_param :azure_storage_account, :string, :default => nil
-    config_param :azure_storage_access_key, :string, :default => nil
+    config_param :azure_storage_access_key, :string, :default => nil, :secret => true
     config_param :azure_container, :string, :default => nil
     config_param :azure_storage_type, :string, :default => 'blob'
     config_param :azure_object_key_format, :string, :default => "%{path}%{time_slice}_%{index}.%{file_extension}"


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameter feature.
This feature works as below:

```log
  <match pattern>
    type azurestorage
    azure_storage_account <your azure storage account>
    azure_storage_access_key xxxxxx
    azure_container <your azure storage container>
    azure_storage_type blob
    store_as gzip
    auto_create_container true
    path logs/
    azure_object_key_format %{path}%{time_slice}_%{index}.%{file_extension}
    buffer_path /var/log/fluent/azurestorage
    time_slice_format %Y%m%d-%H
    time_slice_wait 10m
    utc 
    format out_file
  </match>
</ROOT>
```

And I noticed that missing runtime dependency for `fluent-mixin-config-placeholders` gem.
I also fixed it.