### PR TITLE
fixed azure-adk version.

### DIFF
--- a/fluent-plugin-azurestorage.gemspec
+++ b/fluent-plugin-azurestorage.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "fluentd"
   spec.add_runtime_dependency "fluent-mixin-config-placeholders"
-  spec.add_runtime_dependency "azure"
+  spec.add_runtime_dependency "azure", "0.6.4"
 end


### PR DESCRIPTION
Hi,

Fluentd does not start out an error similar to the following when you take advantage of the latest Azure SDK (0.7.0). I would like to propose fixed version of the Azure SDK to 0.6.4.

```
2015-09-06 03:37:58 +0000 [error]: unexpected error error_class=NameError error=#<NameError: uninitialized constant Azure::BlobService>
```

Please confirm.

Thank you.