### PR TITLE
Updated dependency to Azure Storage SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0
   - 2.1
   - 2.2.0
   - rbx

--- a/fluent-plugin-azurestorage.gemspec
+++ b/fluent-plugin-azurestorage.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "fluentd", [">= 0.10.58", "< 2"]
-  gem.add_dependency "azure", "0.6.4"
+  gem.add_dependency "fluentd", [">= 0.12.0", "< 2"]
+  gem.add_dependency "azure", [">= 0.7.1", "<= 0.7.7"]
   gem.add_dependency "fluent-mixin-config-placeholders", ">= 0.3.0"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "test-unit", ">= 3.0.8"

--- a/lib/fluent/plugin/out_azurestorage.rb
+++ b/lib/fluent/plugin/out_azurestorage.rb
@@ -81,7 +81,7 @@ module Fluent
           config.storage_access_key   = @azure_storage_access_key
         end
       end
-      @bs = Azure::BlobService.new
+      @bs = Azure::Blob::BlobService.new
       @bs.extend UploadService
 
       ensure_container

--- a/test/test_out_azurestorage.rb
+++ b/test/test_out_azurestorage.rb
@@ -21,7 +21,7 @@ class AzureStorageOutputTest < Test::Unit::TestCase
   ]
 
   def create_driver(conf = CONFIG)
-    Fluent::Test::BufferedOutputTestDriver.new(Fluent::AzureStorageOutput) do
+    Fluent::Test::TimeSlicedOutputTestDriver.new(Fluent::AzureStorageOutput) do
       def write(chunk)
         chunk.read
       end
@@ -197,8 +197,8 @@ class AzureStorageOutputTest < Test::Unit::TestCase
     # AzureStorageOutputTest#write returns chunk.read
     data = d.run
 
-    assert_equal %[2011-01-02T13:14:15Z\ttest\t{"a":1}\n] +
-                 %[2011-01-02T13:14:15Z\ttest\t{"a":2}\n],
+    assert_equal [%[2011-01-02T13:14:15Z\ttest\t{"a":1}\n] +
+                 %[2011-01-02T13:14:15Z\ttest\t{"a":2}\n]],
                  data
   end
 


### PR DESCRIPTION
Azure Storage SDK was updated and this introduced incompatibilities with the old plugin code. Currently supported version of Azure SDK are Azure ASM 0.7.1 - 0.7.7. Also updated test cases to be compatible with Fluentd 0.14