### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,48 @@ $ gem install fluent-plugin-azurestorage
 
 ## Configuration
 
+### v0.14 style
+
+```
+<match pattern>
+  type azurestorage
+
+  azure_storage_account    <your azure storage account>
+  azure_storage_access_key <your azure storage access key>
+  azure_container          <your azure storage container>
+  azure_storage_type       blob
+  store_as                 gzip
+  auto_create_container    true
+  path                     logs/
+  azure_object_key_format  %{path}%{time_slice}_%{index}.%{file_extension}
+  time_slice_format        %Y%m%d-%H
+  # if you want to use ${tag} or %Y/%m/%d/ like syntax in path / s3_object_key_format,
+  # need to specify tag for ${tag} and time for %Y/%m/%d in <buffer> argument.
+  <buffer tag,time>
+    @type file
+    path /var/log/fluent/azurestorage
+    timekey 3600 # 1 hour partition
+    timekey_wait 10m
+    timekey_use_utc true # use utc
+  </buffer>
+</match>
+```
+
+For `<buffer>`, you can use any record field in `path` / `azure_object_key_format`.
+
+```
+path logs/${tag}/${foo}
+<buffer tag,foo>
+  # parameters...
+</buffer>
+```
+
+See official article for more detail: Buffer section configurations
+
+Note that this configuration doesn't work with fluentd v0.12.
+
+### v0.12 style
+
 ```
 <match pattern>
   type azurestorage

--- a/fluent-plugin-azurestorage.gemspec
+++ b/fluent-plugin-azurestorage.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "fluentd", [">= 0.12.0", "< 2"]
   gem.add_dependency "azure", [">= 0.7.1", "<= 0.7.7"]
+  gem.add_dependency "uuidtools", ">= 2.1.5"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "test-unit", ">= 3.0.8"
   gem.add_development_dependency "test-unit-rr", ">= 1.0.3"

--- a/fluent-plugin-azurestorage.gemspec
+++ b/fluent-plugin-azurestorage.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "fluentd", [">= 0.12.0", "< 2"]
   gem.add_dependency "azure", [">= 0.7.1", "<= 0.7.7"]
-  gem.add_dependency "fluent-mixin-config-placeholders", ">= 0.3.0"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "test-unit", ">= 3.0.8"
   gem.add_development_dependency "test-unit-rr", ">= 1.0.3"

--- a/fluent-plugin-azurestorage.gemspec
+++ b/fluent-plugin-azurestorage.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "fluentd", [">= 0.12.0", "< 2"]
+  gem.add_dependency "fluentd", [">= 0.14.0", "< 2"]
   gem.add_dependency "azure", [">= 0.7.1", "<= 0.7.7"]
   gem.add_dependency "uuidtools", ">= 2.1.5"
   gem.add_development_dependency "rake", ">= 0.9.2"

--- a/lib/fluent/plugin/out_azurestorage.rb
+++ b/lib/fluent/plugin/out_azurestorage.rb
@@ -52,7 +52,7 @@ module Fluent::Plugin
       begin
         @compressor = COMPRESSOR_REGISTRY.lookup(@store_as).new(:buffer_type => @buffer_type, :log => log)
       rescue => e
-        $log.warn "#{@store_as} not found. Use 'text' instead"
+        log.warn "#{@store_as} not found. Use 'text' instead"
         @compressor = TextCompressor.new
       end
       @compressor.configure(conf)

--- a/lib/fluent/plugin/out_azurestorage.rb
+++ b/lib/fluent/plugin/out_azurestorage.rb
@@ -1,3 +1,8 @@
+require 'azure'
+require 'fluent/plugin/upload_service'
+require 'zlib'
+require 'time'
+require 'tempfile'
 require 'fluent/plugin/output'
 
 module Fluent::Plugin
@@ -8,11 +13,6 @@ module Fluent::Plugin
 
     def initialize
       super
-      require 'azure'
-      require 'fluent/plugin/upload_service'
-      require 'zlib'
-      require 'time'
-      require 'tempfile'
 
       @compressor = nil
     end

--- a/lib/fluent/plugin/out_azurestorage.rb
+++ b/lib/fluent/plugin/out_azurestorage.rb
@@ -163,6 +163,11 @@ module Fluent::Plugin
       end
     end
 
+    def uuid_random
+      require 'uuidtools'
+      ::UUIDTools::UUID.random_create.to_s
+    end
+
     class Compressor
       include Fluent::Configurable
 

--- a/lib/fluent/plugin/out_azurestorage.rb
+++ b/lib/fluent/plugin/out_azurestorage.rb
@@ -166,6 +166,17 @@ module Fluent::Plugin
       ::UUIDTools::UUID.random_create.to_s
     end
 
+    # This is stolen from Fluentd
+    def timekey_to_timeformat(timekey)
+      case timekey
+      when nil          then ''
+      when 0...60       then '%Y%m%d%H%M%S' # 60 exclusive
+      when 60...3600    then '%Y%m%d%H%M'
+      when 3600...86400 then '%Y%m%d%H'
+      else                   '%Y%m%d'
+      end
+    end
+
     class Compressor
       include Fluent::Configurable
 

--- a/lib/fluent/plugin/out_azurestorage.rb
+++ b/lib/fluent/plugin/out_azurestorage.rb
@@ -41,10 +41,6 @@ module Fluent::Plugin
 
     attr_reader :bs
 
-    def placeholders
-      [:percent]
-    end
-
     def configure(conf)
       compat_parameters_convert(conf, :buffer, :formatter, :inject)
       super

--- a/lib/fluent/plugin/out_azurestorage.rb
+++ b/lib/fluent/plugin/out_azurestorage.rb
@@ -116,15 +116,13 @@ module Fluent::Plugin
       begin
         path = @path_slicer.call(@path)
         values_for_object_key = {
-          "path" => path,
-          "time_slice" => time_slice,
-          "file_extension" => @compressor.ext,
-          "index" => i,
-          "uuid_flush" => uuid_random
+          "%{path}" => path,
+          "%{time_slice}" => time_slice,
+          "%{file_extension}" => @compressor.ext,
+          "%{index}" => i,
+          "%{uuid_flush}" => uuid_random
         }
-        storage_path = @azure_object_key_format.gsub(%r(%{[^}]+})) { |expr|
-          values_for_object_key[expr[2...expr.size-1]]
-        }
+        storage_path = @azure_object_key_format.gsub(%r(%{[^}]+}), values_for_object_key)
         storage_path = extract_placeholders(storage_path, metadata)
         if (i > 0) && (storage_path == previous_path)
           raise "duplicated path is generated. use %{index} in azure_object_key_format: path = #{storage_path}"

--- a/lib/fluent/plugin/out_azurestorage.rb
+++ b/lib/fluent/plugin/out_azurestorage.rb
@@ -77,6 +77,9 @@ module Fluent::Plugin
                         else
                           'blob'
                       end
+      # For backward compatibility
+      # TODO: Remove time_slice_format when end of support compat_parameters
+      @configured_time_slice_format = conf['time_slice_format']
     end
 
     def multi_workers_ready?
@@ -107,6 +110,7 @@ module Fluent::Plugin
       i = 0
       metadata = chunk.metadata
       previous_path = nil
+      time_slice_format = @configured_time_slice_format || timekey_to_timeformat(@buffer_config['timekey'])
       time_slice = if metadata.timekey.nil?
                      ''.freeze
                    else

--- a/lib/fluent/plugin/out_azurestorage.rb
+++ b/lib/fluent/plugin/out_azurestorage.rb
@@ -111,12 +111,17 @@ module Fluent::Plugin
       i = 0
       metadata = chunk.metadata
       previous_path = nil
+      time_slice = if metadata.timekey.nil?
+                     ''.freeze
+                   else
+                     Time.at(metadata.timekey).utc.strftime(time_slice_format)
+                   end
 
       begin
         path = @path_slicer.call(@path)
         values_for_object_key = {
           "path" => path,
-          "time_slice" => chunk.key,
+          "time_slice" => time_slice,
           "file_extension" => @compressor.ext,
           "index" => i,
           "uuid_flush" => uuid_random


### PR DESCRIPTION
I've tried to use v0.14 Output plugin API.
This PR contains major update change.
Could you bump up minor version if releasing new version of gem?

Thanks,